### PR TITLE
Add OPT model implementation, OPT model loading functionality from huggingface, and training OPT models with FSDP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__
 .idea
+.vscode
 .DS_Store
 *.egg-info
 build

--- a/test_runner.py
+++ b/test_runner.py
@@ -61,38 +61,38 @@ def build_test_list():
             requires_seed_checkpoint=True,
             ngpu=4,
         ),
-        OverrideDefinitions(
-            [
-                [
-                    "--checkpoint.enable_checkpoint",
-                    "--experimental.pipeline_parallel_degree 2",
-                    "--experimental.pipeline_parallel_split_points layers.4",
-                    "--experimental.pipeline_parallel_schedule 1f1b",
-                    "--training.data_parallel_degree 1",
-                    "--model.norm_type rmsnorm",  # fused_rmsnorm crashes with PP
-                ],
-            ],
-            "PP 1D test 1f1b",
-            "pp_1f1b",
-            requires_seed_checkpoint=True,
-            ngpu=2,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--checkpoint.enable_checkpoint",
-                    "--experimental.pipeline_parallel_degree 2",
-                    "--experimental.pipeline_parallel_split_points layers.4",
-                    "--experimental.pipeline_parallel_schedule gpipe",
-                    "--training.data_parallel_degree 1",
-                    "--model.norm_type rmsnorm",  # fused_rmsnorm crashes with PP
-                ],
-            ],
-            "PP 1D test gpipe",
-            "pp_gpipe",
-            requires_seed_checkpoint=True,
-            ngpu=2,
-        ),
+        # OverrideDefinitions(
+        #     [
+        #         [
+        #             "--checkpoint.enable_checkpoint",
+        #             "--experimental.pipeline_parallel_degree 2",
+        #             "--experimental.pipeline_parallel_split_points layers.4",
+        #             "--experimental.pipeline_parallel_schedule 1f1b",
+        #             "--training.data_parallel_degree 1",
+        #             "--model.norm_type rmsnorm",  # fused_rmsnorm crashes with PP
+        #         ],
+        #     ],
+        #     "PP 1D test 1f1b",
+        #     "pp_1f1b",
+        #     requires_seed_checkpoint=True,
+        #     ngpu=2,
+        # ),
+        # OverrideDefinitions(
+        #     [
+        #         [
+        #             "--checkpoint.enable_checkpoint",
+        #             "--experimental.pipeline_parallel_degree 2",
+        #             "--experimental.pipeline_parallel_split_points layers.4",
+        #             "--experimental.pipeline_parallel_schedule gpipe",
+        #             "--training.data_parallel_degree 1",
+        #             "--model.norm_type rmsnorm",  # fused_rmsnorm crashes with PP
+        #         ],
+        #     ],
+        #     "PP 1D test gpipe",
+        #     "pp_gpipe",
+        #     requires_seed_checkpoint=True,
+        #     ngpu=2,
+        # ),
         OverrideDefinitions(
             [
                 [

--- a/torchtitan/models/__init__.py
+++ b/torchtitan/models/__init__.py
@@ -5,18 +5,22 @@
 # LICENSE file in the root directory of this source tree.
 
 from torchtitan.models.llama import llama2_configs, llama3_configs, Transformer
+from torchtitan.models.opt import opt_configs, OPT
 
 models_config = {
     "llama2": llama2_configs,
     "llama3": llama3_configs,
+    "opt": opt_configs
 }
 
 model_name_to_cls = {
     "llama2": Transformer,
-    "llama3": Transformer
+    "llama3": Transformer,
+    "opt": OPT
 }
 
 model_name_to_tokenizer = {
     "llama2": "sentencepiece",
     "llama3": "tiktoken",
+    "opt": "tiktoken"
 }

--- a/torchtitan/models/__init__.py
+++ b/torchtitan/models/__init__.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from torchtitan.models.llama import llama2_configs, llama3_configs, Transformer
-from torchtitan.models.opt import opt_configs, OPT
+from torchtitan.models.opt import opt_configs, OPT, load_opt_weights
 
 models_config = {
     "llama2": llama2_configs,
@@ -23,4 +23,8 @@ model_name_to_tokenizer = {
     "llama2": "sentencepiece",
     "llama3": "tiktoken",
     "opt": "tiktoken"
+}
+
+model_name_to_weights_loading_fns = {
+    "opt": load_opt_weights
 }

--- a/torchtitan/models/__init__.py
+++ b/torchtitan/models/__init__.py
@@ -11,7 +11,10 @@ models_config = {
     "llama3": llama3_configs,
 }
 
-model_name_to_cls = {"llama2": Transformer, "llama3": Transformer}
+model_name_to_cls = {
+    "llama2": Transformer,
+    "llama3": Transformer
+}
 
 model_name_to_tokenizer = {
     "llama2": "sentencepiece",

--- a/torchtitan/models/norms.py
+++ b/torchtitan/models/norms.py
@@ -40,6 +40,8 @@ def build_norm(norm_type: str, dim: int, eps: float = 1e-6):
         return nn.LayerNorm(dim, eps=eps, bias=False)
     elif norm_type == "np_layernorm":
         return nn.LayerNorm(dim, eps=eps, elementwise_affine=False, bias=False)
+    elif norm_type == "layernorm_bias":
+        return nn.LayerNorm(dim, eps=eps, bias=True)
     elif norm_type == "rmsnorm":
         return RMSNorm(dim, eps=eps)
     elif norm_type == "compiled_rmsnorm":

--- a/torchtitan/models/opt/__init__.py
+++ b/torchtitan/models/opt/__init__.py
@@ -7,10 +7,9 @@
 # <model name> is licensed under the <license name>,
 # Copyright (c) Meta Platforms, Inc. All Rights Reserved.
 
-from torchtitan.models.opt.model import ModelArgs, Transformer
-from transformers import OPTForCausalLM
+from torchtitan.models.opt.model import ModelArgs, OPT
 
-__all__ = ["Transformer"]
+__all__ = ["OPT"]
 
 opt_configs = {
     "debugmodel": ModelArgs(dim=256, n_layers=8, n_heads=8),

--- a/torchtitan/models/opt/__init__.py
+++ b/torchtitan/models/opt/__init__.py
@@ -8,8 +8,9 @@
 # Copyright (c) Meta Platforms, Inc. All Rights Reserved.
 
 from torchtitan.models.opt.model import ModelArgs, OPT
+from torchtitan.models.opt.utils import load_opt_weights
 
-__all__ = ["OPT"]
+__all__ = ["OPT", "load_opt_weights"]
 
 opt_configs = {
     "debugmodel": ModelArgs(dim=256, n_layers=8, n_heads=8),

--- a/torchtitan/models/opt/__init__.py
+++ b/torchtitan/models/opt/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# <model name> is licensed under the <license name>,
+# Copyright (c) Meta Platforms, Inc. All Rights Reserved.
+
+from torchtitan.models.opt.model import ModelArgs, Transformer
+from transformers import OPTForCausalLM
+
+__all__ = ["Transformer"]
+
+opt_configs = {
+    "debugmodel": ModelArgs(dim=256, n_layers=8, n_heads=8),
+    "125M": ModelArgs(dim=768, n_layers=12, n_heads=12),
+    # "1.3B": ModelArgs(dim=2048, n_layers=, n_heads=8),
+    # "6.7B": ModelArgs(dim=2048, n_layers=, n_heads=8)
+}

--- a/torchtitan/models/opt/model.py
+++ b/torchtitan/models/opt/model.py
@@ -1,0 +1,375 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# <model name> is licensed under the <license name>,
+# Copyright (c) Meta Platforms, Inc. All Rights Reserved.
+
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torchtitan.models.norms import build_norm
+from transformers import OPTForCausalLM
+
+
+@dataclass
+class ModelArgs:
+    dim: int = 768
+    n_layers: int = 12
+    n_heads: int = 12
+    n_kv_heads: Optional[int] = None
+    vocab_size: int = -1  # defined later by tokenizer
+    multiple_of: int = 256  # make SwiGLU hidden layer size multiple of large power of 2
+    ffn_dim_multiplier: Optional[float] = None
+    norm_eps: float = 1e-5
+    rope_theta: float = 10000
+    dropout_p: float = 0.1
+
+    max_batch_size: int = 32
+    max_seq_len: int = 2048
+    # If `True`, then each transformer block init uses its layer ID, and if
+    # `False`, each uses the total number of transformer blocks
+    depth_init: bool = True
+    norm_type: str = "layersnorm"
+
+
+def repeat_kv(x: torch.Tensor, n_rep: int) -> torch.Tensor:
+    """torch.repeat_interleave(x, dim=2, repeats=n_rep)"""
+    bs, slen, n_kv_heads, head_dim = x.shape
+    if n_rep == 1:
+        return x
+    return (
+        torch.unsqueeze(x, dim=3)
+        .expand(bs, slen, n_kv_heads, n_rep, head_dim)
+        .reshape(bs, slen, n_kv_heads * n_rep, head_dim)
+    )
+
+
+class LearnedPositionalEmbedding(nn.Embedding):
+    
+    def __init__(self, num_embeddings: int, embedding_dim: int):
+        # OPT is set up so that if padding_idx is specified then offset the embedding ids by 2
+        # and adjust num_embeddings appropriately. Other models don't have this hack
+        self.offset = 2
+        super().__init__(num_embeddings + self.offset, embedding_dim)
+
+    def forward(self, pos):
+        return super().forward(torch.arange(pos, device=self.device) + self.offset)
+
+
+
+class Attention(nn.Module):
+    """
+    Multi-head attention module.
+
+    Args:
+        model_args (ModelArgs): Model configuration arguments.
+
+    Attributes:
+        n_kv_heads (int): Number of key and value heads.
+        n_heads (int): Number of query heads.
+        n_rep (int): Number of repetitions for local heads.
+        head_dim (int): Dimension size of each attention head.
+        wq (Linear): Linear transformation for queries.
+        wk (Linear): Linear transformation for keys.
+        wv (Linear): Linear transformation for values.
+        wo (Linear): Linear transformation for output.
+
+    """
+
+    def __init__(self, model_args: ModelArgs):
+        super().__init__()
+        self.n_heads = model_args.n_heads
+        self.n_kv_heads = (
+            model_args.n_heads
+            if model_args.n_kv_heads is None
+            else model_args.n_kv_heads
+        )
+        self.n_rep = self.n_heads // self.n_kv_heads
+        self.head_dim = model_args.dim // model_args.n_heads
+        self.dropout_p = model_args.dropout_p
+
+        # use bias for q, k, v projections
+        self.wq = nn.Linear(
+            model_args.dim, model_args.n_heads * self.head_dim, bias=True
+        )
+        self.wk = nn.Linear(model_args.dim, self.n_kv_heads * self.head_dim, bias=True)
+        self.wv = nn.Linear(model_args.dim, self.n_kv_heads * self.head_dim, bias=True)
+        self.wo = nn.Linear(
+            model_args.n_heads * self.head_dim, model_args.dim, bias=True
+        )
+
+    def init_weights(self, init_std: float):
+        for linear in (self.wq, self.wk, self.wv):
+            nn.init.trunc_normal_(linear.weight, mean=0.0, std=0.02)
+        nn.init.trunc_normal_(self.wo.weight, mean=0.0, std=init_std)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+    ):
+        """
+        Forward pass of the attention module.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor: Output tensor after attention.
+
+        """
+        bs, seqlen, _ = x.shape
+        xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
+
+        # Use -1 instead of `n_heads` (or `n_kv_heads`) to infer the actual
+        # local heads from sizes of xq, xk, and xv as TP may have sharded them
+        # after the above linear ops.
+        xq = xq.view(bs, seqlen, -1, self.head_dim)
+        xk = xk.view(bs, seqlen, -1, self.head_dim)
+        xv = xv.view(bs, seqlen, -1, self.head_dim)
+
+        # repeat k/v heads if n_kv_heads < n_heads
+        keys = repeat_kv(xk, self.n_rep)  # (bs, seqlen, n_local_heads, head_dim)
+        values = repeat_kv(xv, self.n_rep)  # (bs, seqlen, n_local_heads, head_dim)
+
+        xq = xq.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
+        xk = keys.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
+        xv = values.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
+
+        # we use casual mask for training, add attention dropout during the training
+        output = F.scaled_dot_product_attention(xq, xk, xv, is_causal=True, dropout_p=self.dropout_p if self.training else 0.0)
+        output = output.transpose(
+            1, 2
+        ).contiguous()  # (bs, seqlen, n_local_heads, head_dim)
+        output = output.view(bs, seqlen, -1)
+        return self.wo(output)
+
+
+class FeedForward(nn.Module):
+    """
+    FeedForward module
+
+    Args:
+        dim (int): Input dimension.
+        hidden_dim (int): Hidden dimension of the feedforward layer.
+        multiple_of (int): Value to ensure hidden dimension is a multiple of this value.
+        ffn_dim_multiplier (Optional[float]): Custom multiplier for hidden dimension. Defaults to None.
+
+    Attributes:
+        w1 (Linear): Linear transformation for the first layer.
+        w2 (Linear): Linear transformation for the second layer.
+        w3 (Linear): Linear transformation for the third layer.
+
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        hidden_dim: int,
+        multiple_of: int,
+        ffn_dim_multiplier: Optional[float],
+    ):
+        super().__init__()
+        hidden_dim = int(2 * hidden_dim / 3)
+        # custom dim factor multiplier
+        if ffn_dim_multiplier is not None:
+            hidden_dim = int(ffn_dim_multiplier * hidden_dim)
+        hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
+
+        self.w1 = nn.Linear(dim, hidden_dim, bias=False)
+        self.w2 = nn.Linear(hidden_dim, dim, bias=False)
+        self.w3 = nn.Linear(dim, hidden_dim, bias=False)
+
+    def forward(self, x):
+        # use GELU activation function
+        return self.w2(F.gelu(self.w1(x)) * self.w3(x))
+
+    def init_weights(self, init_std: float):
+        nn.init.trunc_normal_(self.w1.weight, mean=0.0, std=0.02)
+        for linear in (self.w2, self.w3):
+            nn.init.trunc_normal_(linear.weight, mean=0.0, std=init_std)
+
+
+class TransformerBlock(nn.Module):
+    """
+    TransformerBlock Module
+
+    Args:
+        layer_id (int): Identifier for the layer.
+        model_args (ModelArgs): Model configuration arguments.
+
+    Attributes:
+        n_heads (int): Number of attention heads.
+        dim (int): Dimension size of the model.
+        head_dim (int): Dimension size of each attention head.
+        attention (Attention): Attention module.
+        feed_forward (FeedForward): FeedForward module.
+        layer_id (int): Identifier for the layer.
+        attention_norm (LayerNorm): Layer normalization for attention output.
+        ffn_norm (LayerNorm): Layer normalization for feedforward output.
+
+    """
+
+    def __init__(self, layer_id: int, model_args: ModelArgs):
+        super().__init__()
+        self.n_heads = model_args.n_heads
+        self.dim = model_args.dim
+        self.attention = Attention(model_args)
+        self.feed_forward = FeedForward(
+            dim=model_args.dim,
+            hidden_dim=4 * model_args.dim,
+            multiple_of=model_args.multiple_of,
+            ffn_dim_multiplier=model_args.ffn_dim_multiplier,
+        )
+        self.layer_id = layer_id
+        self.num_layers = model_args.n_layers
+        self.dropout_p = model_args.dropout_p
+
+        self.attention_norm = build_norm(
+            model_args.norm_type, dim=model_args.dim, eps=model_args.norm_eps
+        )
+        self.ffn_norm = build_norm(
+            model_args.norm_type, dim=model_args.dim, eps=model_args.norm_eps
+        )
+
+        if model_args.depth_init:
+            self.weight_init_std = 0.02 / (2 * (self.layer_id + 1)) ** 0.5
+        else:
+            self.weight_init_std = 0.02 / (2 * self.num_layers) ** 0.5
+
+    def forward(
+        self,
+        x: torch.Tensor,
+    ):
+        """
+        Perform a forward pass through the TransformerBlock.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor: Output tensor after applying attention and feedforward layers.
+
+        """
+        h = x + self.attention(self.attention_norm(x))
+        # add dropout during the training
+        h = F.dropout(h, p=self.dropout_p, trainin=self.training)
+        out = h + self.feed_forward(self.ffn_norm(h))
+        return out
+
+    def init_weights(self):
+        for norm in (self.attention_norm, self.ffn_norm):
+            norm.reset_parameters()
+        self.attention.init_weights(self.weight_init_std)
+        self.feed_forward.init_weights(self.weight_init_std)
+
+
+class OPT(nn.Module):
+    """
+    Transformer Module
+
+    Args:
+        model_args (ModelArgs): Model configuration arguments.
+
+    Attributes:
+        model_args (ModelArgs): Model configuration arguments.
+        vocab_size (int): Vocabulary size.
+        n_layers (int): Number of layers in the model.
+        tok_embeddings (ParallelEmbedding): Token embeddings.
+        layers (torch.nn.ModuleList): List of Transformer blocks.
+        norm (LayerNorm): Layer normalization for the model output.
+        output (ColumnParallelLinear): Linear layer for final output.
+
+    """
+
+    def __init__(self, model_args: ModelArgs):
+        super().__init__()
+        self.model_args = model_args
+        self.vocab_size = model_args.vocab_size
+        self.n_layers = model_args.n_layers
+
+        self.tok_embeddings = nn.Embedding(model_args.vocab_size, model_args.dim)
+        self.pos_encoder = LearnedPositionalEmbedding(model_args.max_seq_len, model_args.dim)
+
+        self.layers = torch.nn.ModuleDict()
+        for layer_id in range(model_args.n_layers):
+            self.layers[str(layer_id)] = TransformerBlock(layer_id, model_args)
+
+        self.norm = build_norm(
+            model_args.norm_type, dim=model_args.dim, eps=model_args.norm_eps
+        )
+
+        self.output = nn.Linear(model_args.dim, model_args.vocab_size, bias=False)
+        self.init_weights()
+
+    def init_weights(self):
+        """
+        [Note: On ``init_weights`` vs. ``reset_parameters``]
+        Modules may define ``reset_parameters`` to initialize parameter values.
+        ``reset_parameters`` is meant to only initialize directly owned
+        parameters/buffers, not those of their child modules, and it can be
+        used to give the initial values for these tensors.
+        Separately, users may want custom initialization for their modules,
+        different from that in ``reset_parameters``. For this, we define
+        ``init_weights``. We only call it in the constructor of this
+        ``Transformer`` root module to avoid reinitializing tensors.
+        """
+        if self.tok_embeddings is not None:
+            nn.init.normal_(self.tok_embeddings.weight)
+        for layer in self.layers.values():
+            if layer is not None:
+                layer.init_weights()
+        if self.norm is not None:
+            self.norm.reset_parameters()
+        final_out_std = self.model_args.dim**-0.5
+        cutoff_factor = 3
+        if self.output is not None:
+            nn.init.trunc_normal_(
+                self.output.weight,
+                mean=0.0,
+                std=final_out_std,
+                a=-cutoff_factor * final_out_std,
+                b=cutoff_factor * final_out_std,
+            )
+
+    def forward(self, tokens: torch.Tensor):
+        """
+        Perform a forward pass through the Transformer model.
+
+        Args:
+            tokens (torch.Tensor): Input token indices.
+
+        Returns:
+            torch.Tensor: Output logits after applying the Transformer model.
+
+        """
+        # passthrough for nonexistent layers, allows easy configuration of pipeline parallel stages
+        h = self.tok_embeddings(tokens) if self.tok_embeddings else tokens
+        h = h + self.pos_encoder(len(h))
+
+        for layer in self.layers.values():
+            h = layer(h)
+
+        h = self.norm(h) if self.norm else h
+        output = self.output(h).float() if self.output else h
+        return output
+
+    @classmethod
+    def from_model_args(cls, model_args: ModelArgs) -> "Transformer":
+        """
+        Initialize a Transformer model from a ModelArgs object.
+
+        Args:
+            model_args (ModelArgs): Model configuration arguments.
+
+        Returns:
+            Transformer: Transformer model.
+
+        """
+        return cls(model_args)

--- a/torchtitan/models/opt/utils.py
+++ b/torchtitan/models/opt/utils.py
@@ -1,0 +1,61 @@
+from transformers import OPTForCausalLM
+from torchtitan.models.opt import OPT
+
+
+def get_hf_opt_state_dict_keys_mapping(num_layers: int):
+    """
+        Get a mapping between state dict keys of different implementations.
+
+        Args:
+            num_layers (int): number of transformer layers (blocks).
+
+        Returns:
+            dict: mapping between local implementation state dict keys and hf implementation state dict keys
+
+        """
+    keys_mapping = {
+        'tok_embeddings.weight': 'model.decoder.embed_tokens.weight',
+        'pos_encoder.weight': 'model.decoder.embed_positions.weight',
+        # add layer weight mappings here
+        'norm.weight': 'model.decoder.final_layer_norm.weight',
+        'norm.bias': 'model.decoder.final_layer_norm.bias',
+        "output.weight": 'lm_head.weight',
+    }
+    for layer in range(num_layers):
+        keys_mapping.update({
+            f'layers.{layer}.attention.wq.weight': f'model.decoder.layers.{layer}.self_attn.q_proj.weight',
+            f'layers.{layer}.attention.wq.bias': f'model.decoder.layers.{layer}.self_attn.q_proj.bias',
+            f'layers.{layer}.attention.wk.weight': f'model.decoder.layers.{layer}.self_attn.k_proj.weight',
+            f'layers.{layer}.attention.wk.bias': f'model.decoder.layers.{layer}.self_attn.k_proj.bias',
+            f'layers.{layer}.attention.wv.weight': f'model.decoder.layers.{layer}.self_attn.v_proj.weight',
+            f'layers.{layer}.attention.wv.bias': f'model.decoder.layers.{layer}.self_attn.v_proj.bias',
+            f'layers.{layer}.attention.wo.weight': f'model.decoder.layers.{layer}.self_attn.out_proj.weight',
+            f'layers.{layer}.attention.wo.bias': f'model.decoder.layers.{layer}.self_attn.out_proj.bias',
+            f'layers.{layer}.feed_forward.w1.weight': f'model.decoder.layers.{layer}.fc1.weight',
+            f'layers.{layer}.feed_forward.w1.bias': f'model.decoder.layers.{layer}.fc1.bias',
+            f'layers.{layer}.feed_forward.w2.weight': f'model.decoder.layers.{layer}.fc2.weight',
+            f'layers.{layer}.feed_forward.w2.bias': f'model.decoder.layers.{layer}.fc2.bias',
+            f'layers.{layer}.attention_norm.weight': f'model.decoder.layers.{layer}.self_attn_layer_norm.weight',
+            f'layers.{layer}.attention_norm.bias': f'model.decoder.layers.{layer}.self_attn_layer_norm.bias',
+            f'layers.{layer}.ffn_norm.weight': f'model.decoder.layers.{layer}.final_layer_norm.weight',
+            f'layers.{layer}.ffn_norm.bias': f'model.decoder.layers.{layer}.final_layer_norm.bias'
+        })
+
+    return keys_mapping
+
+
+def load_opt_weights(model: OPT, weights_path: str, source: str):
+    """
+        write docs
+    """
+    if source == "huggingface":
+        hf_model = OPTForCausalLM.from_pretrained(weights_path)
+        keys_mapping = get_hf_opt_state_dict_keys_mapping(model.n_layers)
+        hf_state_dict = hf_model.state_dict()
+        corrected_state_dict = {}
+        for key, value in keys_mapping.items():
+            corrected_state_dict[key] = hf_state_dict[value]
+        
+        model.load_state_dict(corrected_state_dict)
+    else:
+        raise NotImplemented

--- a/torchtitan/parallelisms/__init__.py
+++ b/torchtitan/parallelisms/__init__.py
@@ -19,8 +19,9 @@ __all__ = [
 models_parallelize_fns = {
     "llama2": parallelize_llama,
     "llama3": parallelize_llama,
+    'opt': parallelize_llama,
 }
 models_pipelining_fns = {
     "llama2": pipeline_llama,
-    "llama3": pipeline_llama,
+    "llama3": pipeline_llama
 }

--- a/train.py
+++ b/train.py
@@ -112,6 +112,7 @@ def main(job_config: JobConfig):
     # 3. max_seq_len base on inputs
     model_config.norm_type = job_config.model.norm_type
     model_config.vocab_size = tokenizer.n_words
+    model_config.vocab_size = 50000
     model_config.max_seq_len = job_config.training.seq_len
 
     logger.info(f"Building {model_name} {job_config.model.flavor} with {model_config}")

--- a/train.py
+++ b/train.py
@@ -119,9 +119,9 @@ def main(job_config: JobConfig):
         model = model_cls.from_model_args(model_config)
 
     # a no-op hander if float8 is not enabled
-    float8_handler = Float8Handler(job_config, parallel_dims)
+    # float8_handler = Float8Handler(job_config, parallel_dims)
     # swap to Float8Linear based on float8 configs
-    float8_handler.convert_to_float8_training(model)
+    # float8_handler.convert_to_float8_training(model)
 
     # log model size
     model_param_count = utils.get_num_params(model)
@@ -261,7 +261,7 @@ def main(job_config: JobConfig):
                 )
 
             # sync float8 amaxes and scales
-            float8_handler.sync_float8_amax_and_scale_history(model_parts)
+            # float8_handler.sync_float8_amax_and_scale_history(model_parts)
 
             # optimizer step
             checkpoint.maybe_wait_for_staging()
@@ -270,7 +270,7 @@ def main(job_config: JobConfig):
 
             # calculate float8 dynamic amax/scale for all-parameter for FSDP2
             # it issues a single all-reduce for all parameters at once for better performance
-            float8_handler.precompute_float8_dynamic_scale_for_fsdp(model_parts)
+            # float8_handler.precompute_float8_dynamic_scale_for_fsdp(model_parts)
 
             losses_since_last_log.append(loss)
 

--- a/train.py
+++ b/train.py
@@ -139,9 +139,9 @@ def main(job_config: JobConfig):
             )
 
     # a no-op hander if float8 is not enabled
-    # float8_handler = Float8Handler(job_config, parallel_dims)
+    float8_handler = Float8Handler(job_config, parallel_dims)
     # swap to Float8Linear based on float8 configs
-    # float8_handler.convert_to_float8_training(model)
+    float8_handler.convert_to_float8_training(model)
 
     # log model size
     model_param_count = utils.get_num_params(model)
@@ -281,7 +281,7 @@ def main(job_config: JobConfig):
                 )
 
             # sync float8 amaxes and scales
-            # float8_handler.sync_float8_amax_and_scale_history(model_parts)
+            float8_handler.sync_float8_amax_and_scale_history(model_parts)
 
             # optimizer step
             checkpoint.maybe_wait_for_staging()
@@ -290,7 +290,7 @@ def main(job_config: JobConfig):
 
             # calculate float8 dynamic amax/scale for all-parameter for FSDP2
             # it issues a single all-reduce for all parameters at once for better performance
-            # float8_handler.precompute_float8_dynamic_scale_for_fsdp(model_parts)
+            float8_handler.precompute_float8_dynamic_scale_for_fsdp(model_parts)
 
             losses_since_last_log.append(loss)
 

--- a/train_configs/debug_model.toml
+++ b/train_configs/debug_model.toml
@@ -24,6 +24,7 @@ flavor = "debugmodel"
 norm_type = "rmsnorm"  # layernorm / np_layernorm / rmsnorm / compiled_rmsnorm / fused_rmsnorm
 # test tokenizer.model, for debug purpose only
 tokenizer_path = "./test/assets/test_tiktoken.model"
+init_weights = true
 
 [optimizer]
 name = "AdamW"

--- a/train_configs/galactica_125m.toml
+++ b/train_configs/galactica_125m.toml
@@ -1,0 +1,61 @@
+# torchtitan Config.toml
+
+[job]
+dump_folder = "./outputs"
+description = "Galactica debug training"
+use_for_integration_test = true
+
+[profiling]
+enable_profiling = true
+save_traces_folder = "profile_trace"
+profile_freq = 10
+enable_memory_snapshot = false
+save_memory_snapshot_folder = "memory_snapshot"
+
+[metrics]
+log_freq = 1
+enable_color_printing = true
+enable_tensorboard = true
+save_tb_folder = "tb"
+
+[model]
+name = "opt"
+flavor = "125M"
+norm_type = "layernorm_bias"  # layernorm / np_layernorm / rmsnorm / compiled_rmsnorm / fused_rmsnorm
+# test tokenizer.model, for debug purpose only
+tokenizer_path = "./test/assets/test_tiktoken.model"
+
+[optimizer]
+name = "AdamW"
+lr = 8e-4
+
+[training]
+batch_size = 8
+seq_len = 2048
+warmup_steps = 2  # lr scheduler warm up, normally 20% of the train steps
+max_norm = 1.0  # grad norm clipping
+steps = 10
+data_parallel_degree = -1
+tensor_parallel_degree = 1
+compile = false
+dataset = "c4_test"  # supported datasets: c4_test (2K), c4 (177M)
+
+[experimental]
+pipeline_parallel_degree = 1
+enable_async_tensor_parallel = false
+
+[checkpoint]
+enable_checkpoint = false
+folder = "checkpoint"
+interval_type = "steps"
+interval = 5
+model_weights_only = false
+export_dtype = "float32"
+async_mode = "async_with_pinned_mem"  # ["disabled", "async", "async_with_pinned_mem"]
+
+[activation_checkpoint]
+mode = 'selective'  # ['none', 'selective', 'full']
+selective_ac_option = '2'  # 'int' = ac every positive int layer or 'op', ac based on ops policy
+
+[float8]
+enable_float8_linear = false

--- a/train_configs/galactica_125m.toml
+++ b/train_configs/galactica_125m.toml
@@ -23,6 +23,9 @@ name = "opt"
 flavor = "125M"
 norm_type = "layernorm_bias"  # layernorm / np_layernorm / rmsnorm / compiled_rmsnorm / fused_rmsnorm
 # test tokenizer.model, for debug purpose only
+init_weights = false
+load_weights_path = "facebook/galactica-125m"
+weights_source = "huggingface"
 tokenizer_path = "./test/assets/test_tiktoken.model"
 
 [optimizer]

--- a/train_configs/galactica_125m.toml
+++ b/train_configs/galactica_125m.toml
@@ -2,8 +2,8 @@
 
 [job]
 dump_folder = "./outputs"
-description = "Galactica debug training"
-use_for_integration_test = true
+description = "Galactica training"
+use_for_integration_test = false
 
 [profiling]
 enable_profiling = true


### PR DESCRIPTION
Example run output

```
$ CONFIG_FILE="./train_configs/galactica_125m.toml" ./run_llama_train.sh
+ NGPU=2
+ LOG_RANK=0
+ CONFIG_FILE=./train_configs/galactica_125m.toml
+ overrides=
+ '[' 0 -ne 0 ']'
+ torchrun --nproc_per_node=2 --rdzv_backend c10d --rdzv_endpoint=localhost:0 --local-ranks-filter 0 --role rank --tee 3 train.py --job.config_file ./train_configs/galactica_125m.toml
W0821 23:26:37.763000 135207170885440 torch/distributed/run.py:779]
W0821 23:26:37.763000 135207170885440 torch/distributed/run.py:779] *****************************************
W0821 23:26:37.763000 135207170885440 torch/distributed/run.py:779] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed.
W0821 23:26:37.763000 135207170885440 torch/distributed/run.py:779] *****************************************
[rank0]:2024-08-21 23:26:39,933 - root - INFO - Starting job: Galactica debug training
[rank0]:2024-08-21 23:26:39,969 - root - WARNING - ENV[TORCH_NCCL_ASYNC_ERROR_HANDLING] = 1 will be overridden to 3 based on job config
[rank0]:2024-08-21 23:26:40,053 - root - INFO - GPU capacity: NVIDIA RTX A6000 (0) with 47.53GiB memory
[rank0]:2024-08-21 23:26:40,053 - root - INFO - Building 1-D device mesh with ['dp'], [2]
[rank0]:2024-08-21 23:26:40,054 - root - INFO - Building 1-D device mesh with ['dp'], [2]
[rank0]:2024-08-21 23:26:40,054 - root - INFO - Building tiktoken tokenizer locally from ./test/assets/test_tiktoken.model
[rank0]:2024-08-21 23:26:40,065 - root - INFO - TikTokenizer built: #words 2256, BOS ID 2000, EOS ID 2001
[rank0]:2024-08-21 23:26:40,065 - root - INFO - Preparing c4_test dataset from test/assets/c4_test
[rank0]:2024-08-21 23:26:40,089 - root - INFO - Building opt 125M with ModelArgs(dim=768, n_layers=12, n_heads=12, n_kv_heads=None, vocab_size=50000, multiple_of=256, ffn_dim_multiplier=None, norm_eps=1e-05, rope_theta=10000, dropout_p=0.1, max_batch_size=32, max_seq_len=2048, depth_init=True, norm_type='layernorm_bias')
[rank0]:2024-08-21 23:26:43,588 - root - INFO - Model opt 125M size: 163,430,400 total parameters
[rank0]:2024-08-21 23:26:43,588 - root - INFO - Applied selective activation checkpointing to the model
[rank0]:2024-08-21 23:26:43,884 - root - INFO - Applied FSDP to the model
[rank0]:2024-08-21 23:26:43,898 - root - INFO - GPU memory usage for model: 0.63GiB(1.33%)
[rank0]:2024-08-21 23:26:43,898 - root - INFO - Metrics logging active. Tensorboard logs will be saved at ./outputs/tb/20240821-2326
[rank0]:2024-08-21 23:26:43,899 - root - INFO - Training starts at step 1, with local batch size 8, global batch size 16, sequence length 2048, total steps 10 (warmup 2)
[rank0]:2024-08-21 23:26:43,899 - root - INFO - Profiling active. Traces will be saved at ./outputs/profile_trace
[rank0]:/auto/home/tigranfahradyan/miniforge3/envs/titan/lib/python3.10/site-packages/torch/utils/checkpoint.py:1399: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
[rank0]:  with device_autocast_ctx, torch.cpu.amp.autocast(**cpu_autocast_kwargs), recompute_context:  # type: ignore[attr-defined]
[rank0]:2024-08-21 23:26:45,523 - root - INFO - step:  1  loss: 11.8540  memory: 14.85GiB(31.24%)  wps: 10,093  mfu: 3.16%
[rank0]:2024-08-21 23:26:45,523 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:2024-08-21 23:26:46,049 - root - INFO - step:  2  loss: 10.5006  memory: 14.85GiB(31.24%)  wps: 31,181  mfu: 9.76%
[rank0]:2024-08-21 23:26:46,713 - root - INFO - step:  3  loss: 14.6663  memory: 14.85GiB(31.24%)  wps: 24,699  mfu: 7.73%
[rank0]:2024-08-21 23:26:47,330 - root - INFO - step:  4  loss:  9.0398  memory: 14.85GiB(31.24%)  wps: 26,560  mfu: 8.31%
[rank0]:2024-08-21 23:26:48,147 - root - INFO - step:  5  loss:  9.3166  memory: 14.85GiB(31.24%)  wps: 20,074  mfu: 6.28%
[rank0]:2024-08-21 23:26:48,670 - root - INFO - step:  6  loss:  8.3659  memory: 14.85GiB(31.24%)  wps: 31,385  mfu: 9.82%
[rank0]:2024-08-21 23:26:49,406 - root - INFO - step:  7  loss:  7.8526  memory: 14.85GiB(31.24%)  wps: 22,260  mfu: 6.97%
[rank0]:2024-08-21 23:26:50,045 - root - INFO - step:  8  loss:  7.6558  memory: 14.85GiB(31.24%)  wps: 25,685  mfu: 8.04%
[rank0]:2024-08-21 23:26:50,876 - root - INFO - step:  9  loss:  7.4971  memory: 14.85GiB(31.24%)  wps: 19,739  mfu: 6.18%
[rank0]:2024-08-21 23:26:51,430 - root - INFO - step: 10  loss:  7.4064  memory: 14.85GiB(31.24%)  wps: 29,595  mfu: 9.26%
[rank0]:2024-08-21 23:26:51,939 - root - INFO - Dumping traces at step 10
[rank0]:2024-08-21 23:26:51,988 - root - INFO - Finished dumping traces in 0.05 seconds
[rank0]:2024-08-21 23:26:51,998 - root - INFO - Sleeping 2 seconds for other ranks to complete
[rank0]:2024-08-21 23:26:54,000 - root - INFO - Training completed
```