### PR TITLE
Auto restart

### DIFF
--- a/run_llama_train.sh
+++ b/run_llama_train.sh
@@ -11,14 +11,15 @@ set -ex
 # e.g.
 # LOG_RANK=0,1 NGPU=4 ./run_llama_train.sh
 NGPU=${NGPU:-"2"}
-LOG_RANK=${LOG_RANK:-0}
+LOG_RANK=0,1
 CONFIG_FILE=${CONFIG_FILE:-"./train_configs/debug_model.toml"}
+MAX_RESTARTS=5
 
 overrides=""
 if [ $# -ne 0 ]; then
     overrides="$*"
 fi
 
-torchrun --nproc_per_node=${NGPU} --rdzv_backend c10d --rdzv_endpoint="localhost:0" \
+torchrun --nproc_per_node=${NGPU} --rdzv_backend c10d --max-restarts ${MAX_RESTARTS} --rdzv_endpoint="localhost:0" \
 --local-ranks-filter ${LOG_RANK} --role rank --tee 3 \
-train.py --job.config_file ${CONFIG_FILE} $overrides
+train.py --job.config_file ${CONFIG_FILE} $overrides  

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -530,7 +530,7 @@ class JobConfig:
         self.parser.add_argument(
             "--comm.trace_buf_size",
             type=int,
-            default=20000,
+            default=0,
             help="Flight recorder ring buffer size, >0 means recording by default, 0 means disabled",
         )
 


### PR DESCRIPTION
**Context**:  Distributed training jobs sometimes freeze when started, this occurs in this repository as well as the torchtitan codebase. This is due to de-sync state of processes.

This pull request is a step towards alleviating this issue:
- adds explicit setting of auto restart
- auto restart is now set to 5, meaning jobs starting a distributed training job would have to hang 5 times in a row to prevent a run from starting.