### PR TITLE
Set lr schedule

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -181,6 +181,9 @@ class JobConfig:
             "--optimizer.name", type=str, default="AdamW", help="Optimizer to use"
         )
         self.parser.add_argument(
+            "--optimizer.schedule", type=str, default="Linear", help="Optimization schedule to use"
+        )
+        self.parser.add_argument(
             "--optimizer.lr", type=float, default=8e-4, help="Learning rate to use"
         )
         self.parser.add_argument(

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -223,6 +223,19 @@ class JobConfig:
             help="Steps for lr scheduler warmup, normally 1/5 of --training.steps",
         )
         self.parser.add_argument(
+                "--training.decay_steps",
+                type=Optional[int],
+                default=None,
+                help="Steps for lr scheduler decay, default is decay starts immediately after warmup",
+        )
+        self.parser.add_argument(
+                "--training.decay_type",
+                type=str,
+                default="linear",
+                choices = ["linear","cosine"],
+                help="Steps for lr scheduler decay type, defaults to linear",
+        )
+        self.parser.add_argument(
             "--training.max_norm",
             type=Union[float, int],
             default=1.0,

--- a/torchtitan/optimizer.py
+++ b/torchtitan/optimizer.py
@@ -139,6 +139,9 @@ def build_lr_schedulers(optimizers, job_config: JobConfig) -> LambdaLR:
         def step(self):
             for schedulers in self.schedulers:
                 schedulers.step()
+        @property 
+        def last_lr(self):
+            return self.schedulers[0].get_last_lr()[0]
 
     return SchedulersContainer(
         [_build_lr_scheduler(optimizer) for optimizer in optimizers]

--- a/train.py
+++ b/train.py
@@ -229,6 +229,7 @@ def main(job_config: JobConfig):
         f"sequence length {job_config.training.seq_len}, "
         f"total steps {job_config.training.steps} "
         f"(warmup {job_config.training.warmup_steps})"
+        f"(decay {job_config.training.decay_steps})"
     )
     with maybe_enable_profiling(
         job_config, global_step=train_state.step
@@ -270,6 +271,7 @@ def main(job_config: JobConfig):
             # optimizer step
             optimizers.step()
             lr_schedulers.step()
+            lr = lr_schedulers.schedulers[0].get_last_lr()[0]
 
             # calculate float8 dynamic amax/scale for all-parameter for FSDP2
             # it issues a single all-reduce for all parameters at once for better performance
@@ -351,7 +353,8 @@ def main(job_config: JobConfig):
                     f"{color.yellow}memory: {gpu_mem_stats.max_reserved_gib:5.2f}GiB"
                     f"({gpu_mem_stats.max_reserved_pct:.2f}%)  "
                     f"{color.blue}wps: {round(wps):,}  "
-                    f"{color.magenta}mfu: {mfu:.2f}%{color.reset}"
+                    f"{color.magenta}mfu: {mfu:.2f}%  "
+                    f"{color.red}lr: {lr:.2f}{color.reset}"
                 )
 
                 losses_since_last_log.clear()

--- a/train.py
+++ b/train.py
@@ -271,7 +271,6 @@ def main(job_config: JobConfig):
             # optimizer step
             optimizers.step()
             lr_schedulers.step()
-            lr = lr_schedulers.schedulers[0].get_last_lr()[0]
 
             # calculate float8 dynamic amax/scale for all-parameter for FSDP2
             # it issues a single all-reduce for all parameters at once for better performance
@@ -354,7 +353,7 @@ def main(job_config: JobConfig):
                     f"({gpu_mem_stats.max_reserved_pct:.2f}%)  "
                     f"{color.blue}wps: {round(wps):,}  "
                     f"{color.magenta}mfu: {mfu:.2f}%  "
-                    f"{color.red}lr: {lr:.2f}{color.reset}"
+                    f"{color.red}lr: {lr_schedulers.last_lr:.2f}{color.reset}"
                 )
 
                 losses_since_last_log.clear()


### PR DESCRIPTION
**This PR implements the following features:**
1) A warmup stable decay (WSD) schedule framework, allowing to specify the number of decay steps and maintaining a stable LR in between. No setting decay steps means decay will start immediately after warmup (as before)
2) A decay type option which defaults to linear decay but can be set to cosine for a cosine decay.
3) Logging of llr schedule to stdout

**Below is an example of logs from a run implementing the WSD schedule**
Note that LR increases linearly to 1(as a demonstrative example), remains stable and then linearly decreases

```shell
[rank1]:2024-09-02 20:10:50,871 - root - INFO - Applied selective activation checkpointing to the model
[rank1]:2024-09-02 20:10:50,891 - root - INFO - Applied FSDP to the model
[rank1]:2024-09-02 20:10:51,521 - root - INFO - GPU memory usage for model: 0.06GiB(0.14%)
[rank1]:2024-09-02 20:10:51,524 - root - INFO - Training starts at step 1, with local batch size 16, global batch size 32, sequence length 2048, total steps 30 (warmup 10)(decay 10)
[rank1]:2024-09-02 20:10:51,524 - root - INFO - Profiling active. Traces will be saved at ./outputs/profile_trace
[rank0]:2024-09-02 20:10:51,524 - root - INFO - GPU memory usage for model: 0.06GiB(0.14%)
[rank0]:2024-09-02 20:10:51,527 - root - INFO - Training starts at step 1, with local batch size 16, global batch size 32, sequence length 2048, total steps 30 (warmup 10)(decay 10)
[rank0]:2024-09-02 20:10:51,527 - root - INFO - Profiling active. Traces will be saved at ./outputs/profile_trace
[rank1]:/auto/home/philipp/miniforge3/envs/titan/lib/python3.10/site-packages/torch/utils/checkpoint.py:1399: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
[rank1]:  with device_autocast_ctx, torch.cpu.amp.autocast(**cpu_autocast_kwargs), recompute_context:  # type: ignore[attr-defined]
[rank0]:/auto/home/philipp/miniforge3/envs/titan/lib/python3.10/site-packages/torch/utils/checkpoint.py:1399: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
[rank0]:  with device_autocast_ctx, torch.cpu.amp.autocast(**cpu_autocast_kwargs), recompute_context:  # type: ignore[attr-defined]
[rank1]:2024-09-02 20:10:55,385 - root - INFO - step:  1  loss: 11.2973  memory: 12.14GiB(25.54%)  wps: 8,487  mfu: 0.46%  lr: 0.18
[rank1]:2024-09-02 20:10:55,385 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:2024-09-02 20:10:55,385 - root - INFO - step:  1  loss: 11.2973  memory: 12.14GiB(25.54%)  wps: 8,494  mfu: 0.46%  lr: 0.18
[rank0]:2024-09-02 20:10:55,385 - root - INFO - Synchronizing and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:2024-09-02 20:10:56,065 - root - INFO - step:  2  loss: 11.5649  memory: 12.14GiB(25.54%)  wps: 48,218  mfu: 2.60%  lr: 0.27
[rank1]:2024-09-02 20:10:56,065 - root - INFO - step:  2  loss: 11.5649  memory: 12.14GiB(25.54%)  wps: 48,218  mfu: 2.60%  lr: 0.27
[rank1]:2024-09-02 20:10:56,892 - root - INFO - step:  3  loss: 28.5669  memory: 12.14GiB(25.54%)  wps: 39,633  mfu: 2.13%  lr: 0.36
[rank0]:2024-09-02 20:10:56,892 - root - INFO - step:  3  loss: 28.5669  memory: 12.14GiB(25.54%)  wps: 39,633  mfu: 2.13%  lr: 0.36
[rank1]:2024-09-02 20:10:57,732 - root - INFO - step:  4  loss: 19.8453  memory: 12.14GiB(25.54%)  wps: 39,024  mfu: 2.10%  lr: 0.45
[rank0]:2024-09-02 20:10:57,732 - root - INFO - step:  4  loss: 19.8453  memory: 12.14GiB(25.54%)  wps: 39,023  mfu: 2.10%  lr: 0.45
[rank1]:2024-09-02 20:10:58,586 - root - INFO - step:  5  loss: 20.3194  memory: 12.14GiB(25.54%)  wps: 38,403  mfu: 2.07%  lr: 0.55
[rank0]:2024-09-02 20:10:58,586 - root - INFO - step:  5  loss: 20.3194  memory: 12.14GiB(25.54%)  wps: 38,405  mfu: 2.07%  lr: 0.55
[rank1]:2024-09-02 20:10:59,432 - root - INFO - step:  6  loss: 14.6006  memory: 12.14GiB(25.54%)  wps: 38,773  mfu: 2.09%  lr: 0.64
[rank0]:2024-09-02 20:10:59,432 - root - INFO - step:  6  loss: 14.6006  memory: 12.14GiB(25.54%)  wps: 38,774  mfu: 2.09%  lr: 0.64
[rank0]:2024-09-02 20:11:00,272 - root - INFO - step:  7  loss: 31.5746  memory: 12.14GiB(25.54%)  wps: 39,021  mfu: 2.10%  lr: 0.73
[rank1]:2024-09-02 20:11:00,272 - root - INFO - step:  7  loss: 31.5746  memory: 12.14GiB(25.54%)  wps: 39,026  mfu: 2.10%  lr: 0.73
[rank1]:2024-09-02 20:11:01,122 - root - INFO - step:  8  loss: 27.2141  memory: 12.14GiB(25.54%)  wps: 38,570  mfu: 2.08%  lr: 0.82
[rank0]:2024-09-02 20:11:01,122 - root - INFO - step:  8  loss: 27.2141  memory: 12.14GiB(25.54%)  wps: 38,570  mfu: 2.08%  lr: 0.82
[rank0]:2024-09-02 20:11:01,951 - root - INFO - step:  9  loss: 28.9633  memory: 12.14GiB(25.54%)  wps: 39,544  mfu: 2.13%  lr: 0.91
[rank1]:2024-09-02 20:11:01,951 - root - INFO - step:  9  loss: 28.9633  memory: 12.14GiB(25.54%)  wps: 39,544  mfu: 2.13%  lr: 0.91
[rank1]:2024-09-02 20:11:02,767 - root - INFO - step: 10  loss: 35.1867  memory: 12.14GiB(25.54%)  wps: 40,151  mfu: 2.16%  lr: 1.00
[rank0]:2024-09-02 20:11:02,767 - root - INFO - step: 10  loss: 35.1867  memory: 12.14GiB(25.54%)  wps: 40,152  mfu: 2.16%  lr: 1.00
[rank0]:2024-09-02 20:11:03,604 - root - INFO - Dumping traces at step 10
[rank1]:2024-09-02 20:11:03,633 - root - INFO - Dumping traces at step 10
[rank1]:2024-09-02 20:11:03,715 - root - INFO - Finished dumping traces in 0.08 seconds
[rank0]:2024-09-02 20:11:03,706 - root - INFO - Finished dumping traces in 0.10 seconds
[rank1]:2024-09-02 20:11:04,177 - root - INFO - step: 11  loss: 46.5603  memory: 12.14GiB(25.54%)  wps: 23,255  mfu: 1.25%  lr: 1.00
[rank0]:2024-09-02 20:11:04,177 - root - INFO - step: 11  loss: 46.5603  memory: 12.14GiB(25.54%)  wps: 23,255  mfu: 1.25%  lr: 1.00
[rank0]:2024-09-02 20:11:05,007 - root - INFO - step: 12  loss: 86.4646  memory: 12.14GiB(25.54%)  wps: 39,493  mfu: 2.13%  lr: 1.00
[rank1]:2024-09-02 20:11:05,007 - root - INFO - step: 12  loss: 86.4646  memory: 12.14GiB(25.54%)  wps: 39,494  mfu: 2.13%  lr: 1.00
[rank0]:2024-09-02 20:11:05,840 - root - INFO - step: 13  loss: 47.8688  memory: 12.14GiB(25.54%)  wps: 39,361  mfu: 2.12%  lr: 1.00
[rank1]:2024-09-02 20:11:05,840 - root - INFO - step: 13  loss: 47.8688  memory: 12.14GiB(25.54%)  wps: 39,355  mfu: 2.12%  lr: 1.00
[rank0]:2024-09-02 20:11:06,656 - root - INFO - step: 14  loss: 63.8610  memory: 12.14GiB(25.54%)  wps: 40,157  mfu: 2.16%  lr: 1.00
[rank1]:2024-09-02 20:11:06,656 - root - INFO - step: 14  loss: 63.8610  memory: 12.14GiB(25.54%)  wps: 40,154  mfu: 2.16%  lr: 1.00
[rank0]:2024-09-02 20:11:07,472 - root - INFO - step: 15  loss: 69.4592  memory: 12.14GiB(25.54%)  wps: 40,222  mfu: 2.17%  lr: 1.00
[rank1]:2024-09-02 20:11:07,471 - root - INFO - step: 15  loss: 69.4592  memory: 12.14GiB(25.54%)  wps: 40,219  mfu: 2.17%  lr: 1.00
[rank0]:2024-09-02 20:11:08,299 - root - INFO - step: 16  loss: 57.6278  memory: 12.14GiB(25.54%)  wps: 39,630  mfu: 2.13%  lr: 1.00
[rank1]:2024-09-02 20:11:08,299 - root - INFO - step: 16  loss: 57.6278  memory: 12.14GiB(25.54%)  wps: 39,625  mfu: 2.13%  lr: 1.00
[rank0]:2024-09-02 20:11:09,123 - root - INFO - step: 17  loss: 42.1454  memory: 12.14GiB(25.54%)  wps: 39,760  mfu: 2.14%  lr: 1.00
[rank1]:2024-09-02 20:11:09,123 - root - INFO - step: 17  loss: 42.1454  memory: 12.14GiB(25.54%)  wps: 39,760  mfu: 2.14%  lr: 1.00
[rank0]:2024-09-02 20:11:09,945 - root - INFO - step: 18  loss: 41.6432  memory: 12.14GiB(25.54%)  wps: 39,907  mfu: 2.15%  lr: 1.00
[rank1]:2024-09-02 20:11:09,945 - root - INFO - step: 18  loss: 41.6432  memory: 12.14GiB(25.54%)  wps: 39,906  mfu: 2.15%  lr: 1.00
[rank1]:2024-09-02 20:11:10,763 - root - INFO - step: 19  loss: 64.8581  memory: 12.14GiB(25.54%)  wps: 40,069  mfu: 2.16%  lr: 1.00
[rank0]:2024-09-02 20:11:10,763 - root - INFO - step: 19  loss: 64.8581  memory: 12.14GiB(25.54%)  wps: 40,070  mfu: 2.16%  lr: 1.00
[rank0]:2024-09-02 20:11:11,599 - root - INFO - step: 20  loss: 68.5319  memory: 12.14GiB(25.54%)  wps: 39,243  mfu: 2.11%  lr: 1.00
[rank1]:2024-09-02 20:11:11,598 - root - INFO - step: 20  loss: 68.5319  memory: 12.14GiB(25.54%)  wps: 39,242  mfu: 2.11%  lr: 1.00
[rank1]:2024-09-02 20:11:12,489 - root - INFO - Dumping traces at step 20
[rank0]:2024-09-02 20:11:12,559 - root - INFO - Dumping traces at step 20
[rank0]:2024-09-02 20:11:12,633 - root - INFO - Finished dumping traces in 0.07 seconds
[rank1]:2024-09-02 20:11:12,568 - root - INFO - Finished dumping traces in 0.08 seconds
[rank1]:2024-09-02 20:11:13,020 - root - INFO - step: 21  loss: 65.5851  memory: 12.14GiB(25.54%)  wps: 23,061  mfu: 1.24%  lr: 0.90
[rank0]:2024-09-02 20:11:13,020 - root - INFO - step: 21  loss: 65.5851  memory: 12.14GiB(25.54%)  wps: 23,062  mfu: 1.24%  lr: 0.90
[rank1]:2024-09-02 20:11:13,826 - root - INFO - step: 22  loss: 53.2354  memory: 12.14GiB(25.54%)  wps: 40,639  mfu: 2.19%  lr: 0.80
[rank0]:2024-09-02 20:11:13,826 - root - INFO - step: 22  loss: 53.2354  memory: 12.14GiB(25.54%)  wps: 40,642  mfu: 2.19%  lr: 0.80
[rank1]:2024-09-02 20:11:14,645 - root - INFO - step: 23  loss: 51.2361  memory: 12.14GiB(25.54%)  wps: 40,034  mfu: 2.16%  lr: 0.70
[rank0]:2024-09-02 20:11:14,645 - root - INFO - step: 23  loss: 51.2361  memory: 12.14GiB(25.54%)  wps: 40,034  mfu: 2.16%  lr: 0.70
[rank1]:2024-09-02 20:11:15,463 - root - INFO - step: 24  loss: 45.9008  memory: 12.14GiB(25.54%)  wps: 40,100  mfu: 2.16%  lr: 0.60
[rank0]:2024-09-02 20:11:15,463 - root - INFO - step: 24  loss: 45.9008  memory: 12.14GiB(25.54%)  wps: 40,100  mfu: 2.16%  lr: 0.60
[rank1]:2024-09-02 20:11:16,287 - root - INFO - step: 25  loss: 49.2565  memory: 12.14GiB(25.54%)  wps: 39,762  mfu: 2.14%  lr: 0.50
[rank0]:2024-09-02 20:11:16,287 - root - INFO - step: 25  loss: 49.2565  memory: 12.14GiB(25.54%)  wps: 39,762  mfu: 2.14%  lr: 0.50
[rank0]:2024-09-02 20:11:17,103 - root - INFO - step: 26  loss: 42.7910  memory: 12.14GiB(25.54%)  wps: 40,181  mfu: 2.16%  lr: 0.40
[rank1]:2024-09-02 20:11:17,103 - root - INFO - step: 26  loss: 42.7910  memory: 12.14GiB(25.54%)  wps: 40,181  mfu: 2.16%  lr: 0.40
[rank1]:2024-09-02 20:11:17,924 - root - INFO - step: 27  loss: 40.1108  memory: 12.14GiB(25.54%)  wps: 39,948  mfu: 2.15%  lr: 0.30
[rank0]:2024-09-02 20:11:17,924 - root - INFO - step: 27  loss: 40.1108  memory: 12.14GiB(25.54%)  wps: 39,948  mfu: 2.15%  lr: 0.30
[rank0]:2024-09-02 20:11:18,741 - root - INFO - step: 28  loss: 36.2548  memory: 12.14GiB(25.54%)  wps: 40,118  mfu: 2.16%  lr: 0.20
[rank1]:2024-09-02 20:11:18,741 - root - INFO - step: 28  loss: 36.2548  memory: 12.14GiB(25.54%)  wps: 40,119  mfu: 2.16%  lr: 0.20
[rank1]:2024-09-02 20:11:19,569 - root - INFO - step: 29  loss: 31.0963  memory: 12.14GiB(25.54%)  wps: 39,610  mfu: 2.13%  lr: 0.10
[rank0]:2024-09-02 20:11:19,569 - root - INFO - step: 29  loss: 31.0963  memory: 12.14GiB(25.54%)  wps: 39,615  mfu: 2.13%  lr: 0.10
[rank0]:2024-09-02 20:11:20,385 - root - INFO - step: 30  loss: 28.8640  memory: 12.14GiB(25.54%)  wps: 40,170  mfu: 2.16%  lr: 0.00
[rank1]:2024-09-02 20:11:20,385 - root - INFO - step: 30  loss: 28.8640  memory: 12.14GiB(25.54%)  wps: 40,169  mfu: 2.16%  lr: 0.00
[rank1]:2024-09-02 20:11:21,303 - root - INFO - Dumping traces at step 30
[rank0]:2024-09-02 20:11:21,318 - root - INFO - Dumping traces at step 30
[rank1]:2024-09-02 20:11:21,385 - root - INFO - Finished dumping traces in 0.08 seconds
[rank1]:2024-09-02 20:11:21,400 - root - INFO - Training completed
[rank0]:2024-09-02 20:11:21,397 - root - INFO - Finished dumping traces in 0.08 seconds
[rank0]:2024-09-02 20:11:21,398 - root - INFO - Sleeping 2 seconds for other ranks to complete
[rank0]:2024-09-02 20:11:23,399 - root - INFO - Training completed
```
