### PR TITLE
Improve control over dataloader functionality

### DIFF
--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -613,6 +613,20 @@ class JobConfig:
             type=str,
             help="Set the log level, INFO by default"
         )
+        self.parser.add_argument(
+            "--dataloader.num_workers",
+            default = 0,
+            type=int,
+            help="""Set the number of dataloader workers PER RANK, default is 0. 1 is non-blocking.
+            More than 1 may lead to issues with data splitting / duplication"""
+        )
+        self.parser.add_argument(
+            "--dataloader.pin_memory",
+            default = False,
+            type=bool,
+            help= "Whether or not to pin dataloader memory"
+        )
+
 
     def parse_args(self, args_list: list = sys.argv[1:]):
         self.args_list = args_list

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -627,6 +627,15 @@ class JobConfig:
             help= "Whether or not to pin dataloader memory"
         )
 
+        self.parser.add_argument(
+            "--dataloader.special_mode",
+            default = None,
+            choices = ["yield_tensor"],
+            type=str,
+            help= "Enable a special dataloading mode, useful for debugging"
+        )
+
+
 
     def parse_args(self, args_list: list = sys.argv[1:]):
         self.args_list = args_list

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -255,8 +255,11 @@ def build_hf_data_loader(
     special_mode = None,
     context = "train",
 ):
-    store_identifier = f"rankstore_{context}_{dataset_name}"
-    data_completion_store = create_fresh_file_store(store_identifier,world_size)
+    if not infinite:
+        store_identifier = f"rankstore_{context}_{dataset_name}"
+        data_completion_store = create_fresh_file_store(store_identifier,world_size)
+    else:
+        data_completion_store = None
 
     hf_ds = HuggingFaceDataset(
         dataset_name, dataset_path, data_processing_style, tokenizer, seq_len, world_size, rank, infinite, special_mode,store = data_completion_store

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -188,7 +188,7 @@ class DPAwareDataLoader(StatefulDataLoader, Stateful):
     A wrapper around the StatefulDataLoader that ensures that the state is stored only once per DP rank.
     """
 
-    def __init__(self, dp_rank: int, hf_ds: IterableDataset, batch_size: int):
+    def __init__(self, dp_rank: int, hf_ds: IterableDataset, batch_size: int, pin_memory: bool, num_workers: int):
         super().__init__(hf_ds, batch_size)
         self._dp_rank = dp_rank
         self._rank_id = f"dp_rank_{dp_rank}"
@@ -220,9 +220,11 @@ def build_hf_data_loader(
     world_size,
     rank,
     infinite: bool = True,
+    pin_memory: bool = False,
+    num_workers: int = 0
 ):
     hf_ds = HuggingFaceDataset(
         dataset_name, dataset_path, data_processing_style, tokenizer, seq_len, world_size, rank, infinite
     )
 
-    return DPAwareDataLoader(rank, hf_ds, batch_size=batch_size)
+    return DPAwareDataLoader(rank, hf_ds, batch_size=batch_size, pin_memory=pin_memory, num_workers=num_workers)

--- a/torchtitan/datasets/hf_datasets.py
+++ b/torchtitan/datasets/hf_datasets.py
@@ -23,7 +23,7 @@ except ImportError as e:
 
 from torchtitan.tokenizers.tokenizer import Tokenizer
 from torchtitan.logging import logger
-from torchtitan.utils.dataset_utils import chemlactica_style_data_processing
+from torchtitan.utils.dataset_utils import chemlactica_style_data_processing,create_fresh_file_store
 
 from datasets import load_dataset
 from datasets.distributed import split_dataset_by_node
@@ -88,6 +88,7 @@ class HuggingFaceDataset(IterableDataset, Stateful):
         rank: int = 0,
         infinite: bool = False,
         special_mode = None,
+        store = None,
     ) -> None:
         # allow user to pass in a (local or HF hub) path to use unsupported datasets
         if dataset_name not in _supported_datasets:
@@ -125,6 +126,15 @@ class HuggingFaceDataset(IterableDataset, Stateful):
         self._tokenizer = tokenizer
         self.seq_len = seq_len
         self.infinite = infinite
+        self.rank = rank
+        self.world_size = world_size
+
+        # for non sync communication between ranks
+        if not self.infinite and store:
+            self.store = store
+        else:
+            self.store = None
+    
 
         # variables for checkpointing
         self._sample_idx = 0
@@ -135,6 +145,12 @@ class HuggingFaceDataset(IterableDataset, Stateful):
 
         # debugging dataloader yielding
         self.special_mode = str(special_mode)
+
+    def _some_rank_finished(self) -> bool:
+        if not self.infinite and self.store.num_keys() > 1: # one key used for coordination, more than one means one of the ranks exhausted data
+            return True
+        else:
+            return False
 
     def __iter__(self):
         max_buffer_token_len = 1 + self.seq_len
@@ -147,6 +163,8 @@ class HuggingFaceDataset(IterableDataset, Stateful):
                 continue
 
             for sample_json in self._get_data_iter():
+                if self._some_rank_finished():
+                    break
                 sample_text = self.data_processing_fn(sample_json, self.rng)
                 sample_tokens = self._tokenizer.encode(sample_text, bos=True, eos=True)
                 self._all_tokens.extend(sample_tokens)
@@ -161,7 +179,9 @@ class HuggingFaceDataset(IterableDataset, Stateful):
                     yield input, label
 
             if not self.infinite:
+                self.store.set(str(self.rank),"Done")
                 logger.warning(f"Dataset {self.dataset_name} has run out of data")
+                self.store.wait([str(k) for k in range(self.world_size)]) # making sure all ranks get to this point
                 break
             else:
                 # Reset offset for the next iteration
@@ -233,9 +253,13 @@ def build_hf_data_loader(
     pin_memory: bool = False,
     num_workers: int = 0,
     special_mode = None,
+    context = "train",
 ):
+    store_identifier = f"rankstore_{context}_{dataset_name}"
+    data_completion_store = create_fresh_file_store(store_identifier,world_size)
+
     hf_ds = HuggingFaceDataset(
-        dataset_name, dataset_path, data_processing_style, tokenizer, seq_len, world_size, rank, infinite, special_mode
+        dataset_name, dataset_path, data_processing_style, tokenizer, seq_len, world_size, rank, infinite, special_mode,store = data_completion_store
     )
 
     return DPAwareDataLoader(rank, hf_ds, batch_size=batch_size, pin_memory=pin_memory, num_workers=num_workers)

--- a/torchtitan/utils/dataset_utils.py
+++ b/torchtitan/utils/dataset_utils.py
@@ -4,6 +4,19 @@
 import orjson
 import json
 from .text_format_utils import generate_formatted_string, delete_empty_tags
+import torch
+import os
+from pathlib import Path
+
+TEMPORARY_FILES_PATH = Path('/tmp')
+
+def create_fresh_file_store(store_identifier: str, world_size: int):
+    store_file = TEMPORARY_FILES_PATH.joinpath(store_identifier)
+    if store_file.exists():
+        store_file.unlink() # we want to always remove prior files since they don't correspond
+
+    stop_ranks_store = torch.distributed.FileStore(str(store_file),world_size)
+    return stop_ranks_store
 
 
 def load_jsonl_line(jsonl_line):

--- a/train.py
+++ b/train.py
@@ -249,6 +249,7 @@ def main(job_config: JobConfig):
         f"(warmup {job_config.training.warmup_steps})"
         f"(decay {job_config.training.decay_steps})"
     )
+    force_finish_train = False
     with maybe_enable_profiling(
         job_config, global_step=train_state.step
     ) as torch_profiler, maybe_enable_memory_snapshot(
@@ -265,7 +266,10 @@ def main(job_config: JobConfig):
             logger.debug("step")
 
             for _ in range(job_config.training.gradient_accumulation_steps):
-                batch = next(data_iterator)
+                batch = next(data_iterator,None)
+                if not batch:
+                    force_finish_train = True
+                    break
                 input_ids, labels = batch
                 ntokens_since_last_log += labels.numel()
                 input_ids = input_ids.cuda()
@@ -280,6 +284,8 @@ def main(job_config: JobConfig):
                     # need to free to before bwd to avoid peaking memory
                     del pred
                     loss.backward()
+            if force_finish_train:
+                break
             for m in model_parts:
                 torch.nn.utils.clip_grad_norm_(
                     m.parameters(), job_config.training.max_norm, foreach=True

--- a/train.py
+++ b/train.py
@@ -102,7 +102,8 @@ def main(job_config: JobConfig):
         dp_degree,
         dp_rank,
         pin_memory = job_config.dataloader.pin_memory,
-        num_workers = job_config.dataloader.num_workers
+        num_workers = job_config.dataloader.num_workers,
+        special_mode = job_config.dataloader.special_mode,
     )
 
     # build model (using meta init)

--- a/train.py
+++ b/train.py
@@ -101,6 +101,8 @@ def main(job_config: JobConfig):
         job_config.training.seq_len,
         dp_degree,
         dp_rank,
+        pin_memory = job_config.dataloader.pin_memory,
+        num_workers = job_config.dataloader.num_workers
     )
 
     # build model (using meta init)


### PR DESCRIPTION
This PR implements the following changes:
1. Uses a file store to stop fetching batches on all ranks when one rank exhausts a non-infinite dataset (e.g. in the case of validation in the future) **without** forcing sync between ranks. Prior to this change, this would cause hangs. In the case of infinite datasets which loop, or if the dataset is not exhausted before train steps is exceeded, there is no change.
2. Allows for specification of num_workers and pin_memory for dataloader via config file or CLI
3. Implements a tensor_yield dataloader mode for debugging model learning / optimization and identifying dataloading as bottleneck.