### PR TITLE
Better lr tracking

### DIFF
--- a/train.py
+++ b/train.py
@@ -380,7 +380,7 @@ def main(job_config: JobConfig):
                     f"({gpu_mem_stats.max_reserved_pct:.2f}%)  "
                     f"{color.blue}wps: {round(wps):,}  "
                     f"{color.magenta}mfu: {mfu:.2f}%  "
-                    f"{color.red}lr: {lr_schedulers.last_lr:.2f}{color.reset}"
+                    f"{color.red}lr: {lr_schedulers.last_lr:.3e}{color.reset}"
                 )
 
                 losses_since_last_log.clear()

--- a/train.py
+++ b/train.py
@@ -361,6 +361,7 @@ def main(job_config: JobConfig):
                     "loss_metrics/global_max_perplexity": global_max_perplexity,
                     "wps": wps,
                     "mfu(%)": mfu,
+                    "lr": lr_schedulers.last_lr,
                     "time_metrics/end_to_end(s)": time_end_to_end,
                     "time_metrics/data_loading(s)": time_data_loading,
                     "time_metrics/data_loading(%)": time_data_loading_pct,


### PR DESCRIPTION
Fixes a couple of small issues regarding tracking of lr during experiments:
1. Logged lr values were not being formatted in scientific notation, meaning very small learning rates (most learning rates cannot be distiguished with 2 decimal points) would not show up in logs, these are now replaced with correctly formatted values with exponent notation.
![image](https://github.com/user-attachments/assets/d36ae962-9d3f-4527-945c-22321922fa9f)

2. Lr values are now tracked by aim.

![image](https://github.com/user-attachments/assets/51530956-bd98-4490-ad02-f3bbde0d3372)
